### PR TITLE
Quick CSS Switch

### DIFF
--- a/src/renderer/coremods/settings/pages/General.tsx
+++ b/src/renderer/coremods/settings/pages/General.tsx
@@ -105,14 +105,10 @@ export const General = (): React.ReactElement => {
 
       <SwitchItem
         value={quickCss}
-        onChange={() => {
-          if (quickCss) {
-            window.replugged.quickCSS.unload();
-            setQuickCss(false);
-          } else {
-            window.replugged.quickCSS.load();
-            setQuickCss(true);
-          }
+        onChange={(value) => {
+          if (value) window.replugged.quickCSS.load();
+          else window.replugged.quickCSS.unload();
+          setQuickCss(value);
         }}>
         Quick CSS
       </SwitchItem>

--- a/src/renderer/coremods/settings/pages/General.tsx
+++ b/src/renderer/coremods/settings/pages/General.tsx
@@ -47,14 +47,9 @@ function restartModal(doRelaunch = false, onConfirm?: () => void, onCancel?: () 
 }
 
 export const General = (): React.ReactElement => {
-  const { value: expValue, onChange: expOnChange } = util.useSetting(
-    generalSettings,
-    "experiments",
-  );
-  const { value: rdtValue, onChange: rdtOnChange } = util.useSetting(
-    generalSettings,
-    "reactDevTools",
-  );
+  const [quickCss, setQuickCss] = util.useSettingArray(generalSettings, "quickCss");
+  const [expValue, expOnChange] = util.useSettingArray(generalSettings, "experiments");
+  const [rdtValue, rdtOnChange] = util.useSettingArray(generalSettings, "reactDevTools");
 
   const [kKeys, setKKeys] = React.useState<number[]>([]);
 
@@ -109,7 +104,22 @@ export const General = (): React.ReactElement => {
       </SwitchItem>
 
       <SwitchItem
+        value={quickCss}
+        onChange={() => {
+          if (quickCss) {
+            window.replugged.quickCSS.unload();
+            setQuickCss(false);
+          } else {
+            window.replugged.quickCSS.load();
+            setQuickCss(true);
+          }
+        }}>
+        Quick CSS
+      </SwitchItem>
+
+      <SwitchItem
         {...util.useSetting(generalSettings, "autoApplyQuickCss")}
+        disabled={!quickCss}
         note={Messages.REPLUGGED_SETTINGS_QUICKCSS_AUTO_APPLY_DESC}>
         {Messages.REPLUGGED_SETTINGS_QUICKCSS_AUTO_APPLY}
       </SwitchItem>

--- a/src/renderer/coremods/settings/pages/QuickCSS.tsx
+++ b/src/renderer/coremods/settings/pages/QuickCSS.tsx
@@ -3,11 +3,9 @@ import { Messages } from "@common/i18n";
 import { EditorView, basicSetup } from "codemirror";
 import { EditorState } from "@codemirror/state";
 import { css } from "@codemirror/lang-css";
-import { load, unload } from "../../../managers/quick-css";
-import { loadStyleSheet } from "../../../util";
 import { githubDark, githubLight } from "./codemirror-github";
 import { webpack } from "@replugged";
-import { Button, Divider, Flex, SwitchItem, Text } from "@components";
+import { Button, Divider, Flex, Text } from "@components";
 import "./QuickCSS.css";
 import { generalSettings } from "./General";
 
@@ -117,9 +115,9 @@ export const QuickCSS = (): React.ReactElement => {
     container: ref.current,
   });
   const [ready, setReady] = React.useState(false);
+  const quickCssEnabled = generalSettings.get("quickCss");
+  const autoApply = quickCssEnabled && generalSettings.get("autoApplyQuickCss");
 
-  const autoApply = generalSettings.get("autoApplyQuickCss");
-  
   const reload = (): void => window.replugged.quickCSS.reload();
   const reloadAndToast = (): void => {
     reload();
@@ -161,7 +159,6 @@ export const QuickCSS = (): React.ReactElement => {
   }, []);
 
   const [reloadTimer, setReloadTimer] = React.useState<NodeJS.Timeout | undefined>(undefined);
-  const [quickCss, setQuickCss] = React.useState(generalSettings.get('cssToggle'))
 
   React.useEffect(() => {
     if (!ready) return;
@@ -177,7 +174,7 @@ export const QuickCSS = (): React.ReactElement => {
       <Flex justify={Flex.Justify.BETWEEN} align={Flex.Align.START}>
         <Text.H2>{Messages.REPLUGGED_QUICKCSS}</Text.H2>
         <div style={{ display: "flex" }}>
-          {autoApply ? null : (
+          {!quickCssEnabled || autoApply ? null : (
             <Button onClick={reloadAndToast}>{Messages.REPLUGGED_QUICKCSS_CHANGES_APPLY}</Button>
           )}
           <Button
@@ -189,20 +186,6 @@ export const QuickCSS = (): React.ReactElement => {
         </div>
       </Flex>
       <Divider style={{ margin: "20px 0px" }} />
-      <SwitchItem
-        value={quickCss}
-        onChange={() => {
-          if (quickCss) {
-            unload();
-          } else {
-            load();
-          }
-          setQuickCss((prev) => {
-            generalSettings.set('cssToggle', !prev)
-            return !prev});
-        }}>
-        Quick CSS
-      </SwitchItem>
       <div ref={ref} id="replugged-quickcss-wrapper" />
     </>
   );

--- a/src/renderer/managers/ignition.ts
+++ b/src/renderer/managers/ignition.ts
@@ -39,9 +39,8 @@ export async function start(): Promise<void> {
   started = true;
 
   // Quick CSS needs to be called after themes are loaded so that it will override the theme's CSS
-  if (generalSettings.get("cssToggle", true))
-  {
-    quickCSS.load(); 
+  if (generalSettings.get("quickCss")) {
+    quickCSS.load();
   }
 
   // Want to make sure all addons are initialized before starting auto-update checking

--- a/src/renderer/managers/quick-css.ts
+++ b/src/renderer/managers/quick-css.ts
@@ -1,4 +1,3 @@
-import { generalSettings } from "../coremods/settings/pages";
 import { loadStyleSheet } from "../util";
 
 let el: HTMLLinkElement | undefined;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -13,7 +13,7 @@ export type GeneralSettings = {
   showWelcomeNoticeOnOpen?: boolean;
   addonEmbeds?: boolean;
   reactDevTools?: boolean;
-  cssToggle?: boolean;
+  quickCss?: boolean;
 };
 
 export const defaultSettings = {
@@ -24,5 +24,5 @@ export const defaultSettings = {
   showWelcomeNoticeOnOpen: true,
   reactDevTools: false,
   addonEmbeds: true,
-  cssToggle: true,
+  quickCss: true,
 } satisfies Partial<GeneralSettings>;


### PR DESCRIPTION
- Added Switch For Quick CSS in General Settings
- Stopped CSS from applying at startup or when QuickCSS is open if the setting is turned off
- Stopped QuickCSS from auto-applying when setting turned off
- Removed the option to apply quick CSS if the setting is turned off
- switched `util.useSetting` to `util.useSettingArray` in general settings